### PR TITLE
feat: update contact and share options, add author information

### DIFF
--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -2,6 +2,7 @@
 
 - type: github
   icon: "fab fa-github"
+  url: "https://github.com/YuryKabernik/"
 
 - type: linkedin
   icon: "fab fa-linkedin" # icons powered by <https://fontawesome.com/>

--- a/_data/share.yml
+++ b/_data/share.yml
@@ -14,6 +14,10 @@ platforms:
     icon: "fab fa-telegram"
     link: "https://t.me/share/url?url=URL&text=TITLE"
 
+  - type: Linkedin
+    icon: "fab fa-linkedin"
+    link: "https://www.linkedin.com/feed/?shareActive=true&shareUrl=URL"
+
   # Uncomment below if you need to.
   #
   # - type: Linkedin

--- a/_posts/2025-09-10-polymorphic-http-requests-handling.md
+++ b/_posts/2025-09-10-polymorphic-http-requests-handling.md
@@ -2,6 +2,7 @@
 title: "Polymorphic Serialization in .NET: OpenAPI Discriminators in Action"
 description: "Learn how to implement polymorphic JSON serialization in .NET using OpenAPI discriminators and `System.Text.Json`."
 date: 2025-09-10 00:00:01 +0200
+author: Yury Kabernik-Berazouski
 categories: .NET
 tags: dotnet openapi discriminator webapi csharp serialization
 image:

--- a/_posts/2025-10-10-lean-methodology.md
+++ b/_posts/2025-10-10-lean-methodology.md
@@ -2,6 +2,7 @@
 title: "Lean: Streamlining Software Production"
 description: "Lean methodology focuses on maximizing customer value while minimizing waste, originating from Toyota's production system in the 1950s."
 date: 2025-10-10 00:00:01 +0200
+author: Yury Kabernik-Berazouski
 categories: Methodology
 tags: lean methodology toyota value-stream-mapping waste-reduction continuous-improvement
 image:

--- a/_posts/2025-11-10-waterfall-methodology.md
+++ b/_posts/2025-11-10-waterfall-methodology.md
@@ -2,6 +2,7 @@
 title: "Waterfall: Securing Requirements with Phase-Gated Development"
 description: "A phase-gated approach to software development based on Royce's 1970 model, emphasizing sequential stages, documentation, and early risk reduction."
 date: 2025-11-10 00:00:01 +0200
+author: Yury Kabernik-Berazouski
 categories: Methodology
 tags: waterfall methodology royce sdlc sequential-development documentation
 image:

--- a/_posts/2025-12-10-agile-methodology.md
+++ b/_posts/2025-12-10-agile-methodology.md
@@ -2,6 +2,7 @@
 title: "Agile: Embracing Change with Iterative Development"
 description: "Agile software development embraces iterative delivery, self-organizing teams, and continuous adaptation to rapidly changing requirements."
 date: 2025-12-10 00:00:01 +0200
+author: Yury Kabernik-Berazouski
 categories: Methodology
 tags: agile methodology scrum kanban iterative-development agile-manifesto sprints
 image:

--- a/_posts/2026-01-20-lean-waterfall-agile-comparison.md
+++ b/_posts/2026-01-20-lean-waterfall-agile-comparison.md
@@ -2,6 +2,7 @@
 title: "Comparing Lean, Waterfall, and Agile Methodologies"
 description: "A side-by-side comparison of Lean, Waterfall, and Agile methodologies to help choose the right approach for your software project."
 date: 2026-01-20 00:00:01 +0200
+author: Yury Kabernik-Berazouski
 categories: Methodology
 tags: lean waterfall agile methodology sdlc project-management software-development
 image:

--- a/_posts/2026-03-21-cors-configuration-via-options-pattern.md
+++ b/_posts/2026-03-21-cors-configuration-via-options-pattern.md
@@ -2,6 +2,7 @@
 title: "Configuring CORS with the Options Pattern"
 description: "How to clean Startup in ASP.NET Core using the Options pattern for a more testable and maintainable CORS policy setup."
 date: 2026-06-07 00:00:01 +0200
+author: Yury Kabernik-Berazouski
 categories: .NET
 tags: dotnet options-pattern cors aspnet-core middleware patterns access-control browser
 image:

--- a/_tabs/about.md
+++ b/_tabs/about.md
@@ -4,5 +4,28 @@ icon: fas fa-info-circle
 order: 4
 ---
 
-> Add Markdown syntax content to file `_tabs/about.md`{: .filepath } and it will show up on this page.
-{: .prompt-tip }
+## Hi, I am Yury Kabernik-Berazouski
+
+Welcome, and thank you for visiting my blog and paying attention to my work. I hope you find something interesting and useful here that makes you want to come back.
+
+## Let me introduce myself
+
+I am a full-stack software engineer working with .NET, C#, JavaScript, and Angular. I focus on building reliable, maintainable web applications and backend services with a practical, quality-first mindset.
+
+## A bit more personal
+
+I am a curious person who enjoys discovering places where culture, nature, and craftsmanship meet. Outside of software, I am especially interested in visiting art museums and galleries. Among my favorite museums are Museum Wiesbaden, Louvre Museum, Austrian Gallery Belvedere, Van Gogh Museum, and Munch Art Museum.
+
+I also enjoy whisky tasting, especially smooth blended styles such as Johnnie Walker, Grant's, and Ballantine's. I appreciate their soft, slightly smoky character and notes of honey and vanilla.
+
+On Saturdays, I love hiking in the Odenwald and exploring forest trails with picnic stops across the natural landscape of the UNESCO Geopark Bergstrasse-Odenwald.
+
+## What I focus on
+
+- Building clean, maintainable web applications and APIs
+- Improving reliability through testing, observability, and iterative refactoring
+- Keeping delivery practical and value-driven with Agile and Lean principles
+
+## Before you go
+
+Feel free to explore my recent posts. If you find something interesting, I would really appreciate you sharing it with your friends and colleagues.


### PR DESCRIPTION
This pull request introduces author attribution to several blog posts, updates contact and sharing information, and adds a detailed personal introduction to the About page. The main themes are content attribution, contact/share enhancements, and improved site introduction.

**Content attribution:**

* Added `author: Yury Kabernik-Berazouski` to multiple blog posts, ensuring consistent author credit across posts on Lean, Waterfall, Agile, methodology comparisons, .NET serialization, and CORS configuration. [[1]](diffhunk://#diff-84e73810986ffb2bdd3b97f75ededb7c63bbb004845deb24d7fb44d158519b4cR5) [[2]](diffhunk://#diff-4e4855e07d48455d3c56b6e72626573bc42619c55e59f05e55894aaf359f229dR5) [[3]](diffhunk://#diff-f9493f7268703c0a3b1004acae030899a5f6df40d1957903b3caac24a99db06fR5) [[4]](diffhunk://#diff-2bad2ea0cc68e7b9613007b936cf3b7656e61e4cb32d78e73d184846911e6858R5) [[5]](diffhunk://#diff-b0c524d190147c1faed22f789b93eaa40a4ff2fdbe9c737a6389824c94c1e07dR5) [[6]](diffhunk://#diff-40bc91b40ac5e94d3a02edbb7777528c82642864c83d1cd36bddafa022911a51R5)

**Contact and sharing enhancements:**

* Added a GitHub profile URL to the contact configuration in `_data/contact.yml`.
* Enabled LinkedIn as a sharing option in `_data/share.yml` by adding a new entry to the platforms list.

**Site introduction improvement:**

* Replaced the placeholder content in `_tabs/about.md` with a comprehensive personal introduction, including background, interests, and focus areas.